### PR TITLE
Ability to disable tomcat CSRF policy + new environment variables for configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN yum update -y && \
                    libXinerama \
                    libXrender \
                    supervisor \
-                   wget && \
+                   wget \
+									 patch && \
     yum clean all
 
 # install java
@@ -36,6 +37,9 @@ RUN /tmp/install_mysql_connector.sh && \
 # this is for LDAP configuration
 RUN mkdir -p /alfresco/tomcat/shared/classes/alfresco/extension/subsystems/Authentication/ldap/ldap1/
 COPY assets/ldap-authentication.properties /alfresco/tomcat/shared/classes/alfresco/extension/subsystems/Authentication/ldap/ldap1/ldap-authentication.properties
+
+# adding path file used to disable tomcat CSRF
+COPY assets/disable_tomcat_CSRF.patch /alfresco/disable_tomcat_CSRF.patch
 
 # install scripts
 COPY assets/init.sh /alfresco/init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum update -y && \
                    libXrender \
                    supervisor \
                    wget \
-									 patch && \
+                   patch && \
     yum clean all
 
 # install java

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mount the appropriate volume, connect to a remote PostgreSQL database, and use
 an external LDAP server for authentication:
 ```bash
 docker run --name='alfresco' -it --rm -p 445:445 -p 7070:7070 -p 8080:8080 \
-    -v '/host/alfresco_data:/alfresco/alf_data' \
+    -v '/host/alfresco_data:/content' \
     -e 'CONTENT_STORE=/content' \
     -e 'LDAP_ENABLED=true' \
     -e 'LDAP_AUTH_USERNAMEFORMAT=uid=%s,cn=users,cn=accounts,dc=example,dc=com' \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ an external LDAP server for authentication:
 ```bash
 docker run --name='alfresco' -it --rm -p 445:445 -p 7070:7070 -p 8080:8080 \
     -v /host/alfresco_data:/alfresco/alf_data \
-    -e 'CONTENT_STORE=/alfresco/alf_data' \
+    -e 'CONTENT_STORE=/content' \
     -e 'LDAP_ENABLED=true' \
     -e 'LDAP_AUTH_USERNAMEFORMAT=uid=%s,cn=users,cn=accounts,dc=example,dc=com' \
     -e 'LDAP_URL=ldap://ipa.example.com:389' \
@@ -95,14 +95,16 @@ If you want to use this image in production, then please read on.
 ## Datastore
 To persist data, you will want to make sure to specify and mount the
 CONTENT_STORE, example:
-* `/alfresco/alf_data`
+* `/content`
 
 Volumes can be mounted by passing the **'-v'** option to the docker run command.
 The following is an example:
 ```bash
-docker run --name alfresco -it --rm -v /host/alfresco_data:/alfresco/alf_data
+docker run --name alfresco -it --rm -v /host/alfresco_data:/content
 ```
-
+:warning:<br>
+The directory "/alfresco/alf_data" in this container already have data (keystore,...).<br>
+If you mount a volume at this location using "-v", alfresco may not work.
 
 ## Database
 If the `DB_HOST` environment variable is not set, or set to localhost, then the
@@ -122,6 +124,8 @@ GRANT ALL PRIVILEGES ON DATABASE alfresco TO alfresco;
 Below is the complete list of currently available parameters that can be set
 using environment variables.
 - **ALFRESCO_HOSTNAME**: hostname of the Alfresco server; default = `localhost`
+- **ALFRESCO_PORT**: port for afresco to listen to; default = `8080` if protocol is http or `8443` if protocol is https
+- **ALFRESCO_PROTOCOL**: protocol use by alfresco to generate links; default = `http`
 - **CIFS_ENABLED**: whether or not to enable CIFS; default = `true`
 - **CIFS_SERVER_NAME**: hostname of the CIFS server; default = `localhost`
 - **CIFS_DOMAIN**: domain of the CIFS server; default = `WORKGROUP`
@@ -152,6 +156,10 @@ using environment variables.
 - **MAIL_SMTPS_STARTTLS_ENABLE**: use starttls or not; default = `false`
 - **NFS_ENABLED**: whether or not to enable NFS; default = `true`
 - **SHARE_HOSTNAME**: hostname of the share server; default = `localhost`
+- **SHARE_PORT**: port for share to listen to; default = `8080` if protocol is http or `8443` if protocol is https
+- **SHARE_PROTOCOL**: protocol use by share to generate links; default = `http`
+- **SYSTEM_SERVERMODE**: the server running mode for you system; default = `PRODUCTION`
+- **TOMCAT_CSRF_ENABLED**: Disable the tomcat CSRF policy, values: `true` or `false`; default = `false`
 
 
 # Upgrading

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ mount the appropriate volume, connect to a remote PostgreSQL database, and use
 an external LDAP server for authentication:
 ```bash
 docker run --name='alfresco' -it --rm -p 445:445 -p 7070:7070 -p 8080:8080 \
-    -v /host/alfresco_data:/alfresco/alf_data \
+    -v '/host/alfresco_data:/alfresco/alf_data' \
     -e 'CONTENT_STORE=/content' \
     -e 'LDAP_ENABLED=true' \
     -e 'LDAP_AUTH_USERNAMEFORMAT=uid=%s,cn=users,cn=accounts,dc=example,dc=com' \

--- a/assets/disable_tomcat_CSRF.patch
+++ b/assets/disable_tomcat_CSRF.patch
@@ -1,0 +1,14 @@
+--- /alfresco/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml	2016-04-19 16:28:52.044733885 +0200
++++ /alfresco/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml.new	2016-04-19 16:27:11.833719429 +0200
+@@ -37,11 +37,9 @@
+    </config>
+ 
+    <!-- Disable the CSRF Token Filter -->
+-   <!--
+    <config evaluator="string-compare" condition="CSRFPolicy" replace="true">
+       <filter/>
+    </config>
+-   -->
+ 
+    <!--
+       To run the CSRF Token Filter behind 1 or more proxies that do not rewrite the Origin or Referere headers:

--- a/assets/init.sh
+++ b/assets/init.sh
@@ -7,20 +7,27 @@ CATALINA_HOME=$ALF_HOME/tomcat
 
 ALFRESCO_HOSTNAME=${ALFRESCO_HOSTNAME:-127.0.0.1}
 ALFRESCO_PROTOCOL=${ALFRESCO_PROTOCOL:-http}
-ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
-if [ "${ALFRESCO_PROTOCOL,,}" = "https" ]; then
-  ALFRESCO_PORT=${ALFRESCO_PORT:-8443}
-else
-  ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
+ALFRESCO_PORT=${ALFRESCO_PORT:-null}
+#do not change alfresco_port if specified as environment variable
+if [ "$ALFRESCO_PORT" == 'null'] ;then
+  if [ "${ALFRESCO_PROTOCOL,,}" = "https" ]; then
+    ALFRESCO_PORT=${ALFRESCO_PORT:-8443}
+  else
+    ALFRESCO_PORT=${ALFRESCO_PORT:-8080}
+  fi
 fi
+
 
 SHARE_HOSTNAME=${SHARE_HOSTNAME:-127.0.0.1}
 SHARE_PROTOCOL=${SHARE_PROTOCOL:-http}
-SHARE_PORT=${SHARE_PORT:-8080}
-if [ "${SHARE_PROTOCOL,,}" = "https" ]; then
-  SHARE_PORT=${SHARE_PORT:-8443}
-else
-  SHARE_PORT=${SHARE_PORT:-8080}
+SHARE_PORT=${SHARE_PORT:-null}
+#do not change share_port if specified as environment variable
+if [ "$SHARE_PORT" == 'null'] ;then
+  if [ "${SHARE_PROTOCOL,,}" = "https" ]; then
+    SHARE_PORT=${SHARE_PORT:-8443}
+  else
+    SHARE_PORT=${SHARE_PORT:-8080}
+  fi
 fi
 
 DB_KIND=${DB_KIND:-postgresql}
@@ -98,8 +105,15 @@ function cfg_replace_option {
 function tweak_alfresco {
   ALFRESCO_GLOBAL_PROPERTIES=$CATALINA_HOME/shared/classes/alfresco-global.properties
 
+  #alfresco host+proto+port
   cfg_replace_option alfresco.host $ALFRESCO_HOSTNAME $ALFRESCO_GLOBAL_PROPERTIES
+  cfg_replace_option alfresco.protocol $ALFRESCO_PROTOCOL $ALFRESCO_GLOBAL_PROPERTIES
+  cfg_replace_option alfresco.port $ALFRESCO_PORT $ALFRESCO_GLOBAL_PROPERTIES
+
+  #share host+proto+port
   cfg_replace_option share.host $SHARE_HOSTNAME $ALFRESCO_GLOBAL_PROPERTIES
+  cfg_replace_option share.protocol $SHARE_PROTOCOL $ALFRESCO_GLOBAL_PROPERTIES
+  cfg_replace_option share.port $SHARE_PORT $ALFRESCO_GLOBAL_PROPERTIES
 
   #set server mode
   cfg_replace_option system.serverMode $SYSTEM_SERVERMODE $ALFRESCO_GLOBAL_PROPERTIES


### PR DESCRIPTION
I needed to disable CSRF because we already perform such think in our reverse proxy. I used a "patch" file because several lines were involved in this modification.

Our alfresco is running in http behind a https reverse-proxy, so I needed to set "port" and "procotol" according to this.

I also added the servermode property that was available, but not set before into alfresco's config file.

Final I change the example related to the "content store" and the mounting of an external volume, according to an old issue. (I ran into this to).

Best regards.
Damien