### PR TITLE
LDAP: add search and bind support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ using environment variables.
 - **FTP_PORT**: port of the database server; default = `5432`
 - **LDAP_ENABLED**: whether or not to enable LDAP; default = `false`
 - **LDAP_KIND**: ldap (e.g. for OpenLDAP) or ldap-ad (Active Directory); default = ldap
-- **LDAP_AUTH_USERNAMEFORMAT**: default = `uid=%s,cn=users,cn=accounts,dc=example,dc=com`
+- **LDAP_AUTH_USERNAMEFORMAT**: Specifies how to map the user identifier entered by the user to that passed through to LDAP. Could be empty to enable "search and bind" method. default = `uid=%s,cn=users,cn=accounts,dc=example,dc=com`
 - **LDAP_URL**: URL of LDAP server; default = `ldap://ldap.example.com:389`
 - **LDAP_DEFAULT_ADMINS**: comma separated list of admin names in ldap; default = `admin`
 - **LDAP_SECURITY_PRINCIPAL**: default = `uid=admin,cn=users,cn=accounts,dc=example,dc=com`
 - **LDAP_SECURITY_CREDENTIALS**: default = `password`
 - **LDAP_GROUP_SEARCHBASE**: default = `cn=groups,cn=accounts,dc=example,dc=com`
 - **LDAP_USER_SEARCHBASE**: default = `cn=users,cn=accounts,dc=example,dc=com`
+- **LDAP_USER_ATTRIBUTENAME**: The attribute name on people objects found in LDAP to use as the uid in Alfresco (commonly `uid` in OpenLDAP or `sAMAccountName` in Active Directory); default = `uid`
 - **MAIL_HOST**: hostname or IP where email should be sent; default = `localhost`
 - **MAIL_PORT**: default = `25`
 - **MAIL_USERNAME**: username to connect to the smtp server

--- a/assets/init.sh
+++ b/assets/init.sh
@@ -80,13 +80,14 @@ NFS_ENABLED=${NFS_ENABLED:-true}
 
 LDAP_ENABLED=${LDAP_ENABLED:-false}
 LDAP_KIND=${LDAP_KIND:-ldap}
-LDAP_AUTH_USERNAMEFORMAT=${LDAP_AUTH_USERNAMEFORMAT:-uid=%s,cn=users,cn=accounts,dc=example,dc=com}
+LDAP_AUTH_USERNAMEFORMAT=${LDAP_AUTH_USERNAMEFORMAT-uid=%s,cn=users,cn=accounts,dc=example,dc=com}
 LDAP_URL=${LDAP_URL:-ldap://ldap.example.com:389}
 LDAP_DEFAULT_ADMINS=${LDAP_DEFAULT_ADMINS:-admin}
 LDAP_SECURITY_PRINCIPAL=${LDAP_SECURITY_PRINCIPAL:-uid=admin,cn=users,cn=accounts,dc=example,dc=com}
 LDAP_SECURITY_CREDENTIALS=${LDAP_SECURITY_CREDENTIALS:-password}
 LDAP_GROUP_SEARCHBASE=${LDAP_GROUP_SEARCHBASE:-cn=groups,cn=accounts,dc=example,dc=com}
 LDAP_USER_SEARCHBASE=${LDAP_USER_SEARCHBASE:-cn=users,cn=accounts,dc=example,dc=com}
+LDAP_USER_ATTRIBUTENAME=${LDAP_USER_ATTRIBUTENAME:-uid}
 
 CONTENT_STORE=${CONTENT_STORE:-/content}
 
@@ -165,13 +166,14 @@ function tweak_alfresco {
     # now make substitutions in the LDAP config file
     LDAP_CONFIG_FILE=$CATALINA_HOME/shared/classes/alfresco/extension/subsystems/Authentication/${LDAP_KIND}/ldap1/${LDAP_KIND}-authentication.properties
 
-    cfg_replace_option ldap.authentication.userNameFormat $LDAP_AUTH_USERNAMEFORMAT $LDAP_CONFIG_FILE
+    cfg_replace_option "ldap.authentication.userNameFormat" "$LDAP_AUTH_USERNAMEFORMAT" "$LDAP_CONFIG_FILE"
     cfg_replace_option ldap.authentication.java.naming.provider.url $LDAP_URL $LDAP_CONFIG_FILE
     cfg_replace_option ldap.authentication.defaultAdministratorUserNames $LDAP_DEFAULT_ADMINS $LDAP_CONFIG_FILE
     cfg_replace_option ldap.synchronization.java.naming.security.principal $LDAP_SECURITY_PRINCIPAL $LDAP_CONFIG_FILE
     cfg_replace_option ldap.synchronization.java.naming.security.credentials $LDAP_SECURITY_CREDENTIALS $LDAP_CONFIG_FILE
     cfg_replace_option ldap.synchronization.groupSearchBase $LDAP_GROUP_SEARCHBASE $LDAP_CONFIG_FILE
     cfg_replace_option ldap.synchronization.userSearchBase $LDAP_USER_SEARCHBASE $LDAP_CONFIG_FILE
+    cfg_replace_option ldap.synchronization.userIdAttributeName $LDAP_USER_ATTRIBUTENAME $LDAP_CONFIG_FILE
   else
     cfg_replace_option authentication.chain "alfrescoNtlm1:alfrescoNtlm" $ALFRESCO_GLOBAL_PROPERTIES
   fi

--- a/assets/ldap-ad-authentication.properties
+++ b/assets/ldap-ad-authentication.properties
@@ -87,7 +87,7 @@ ldap.synchronization.modifyTimestampAttributeName=whenChanged
 ldap.synchronization.timestampFormat=yyyyMMddHHmmss'.0Z'
 
 # The attribute name on people objects found in LDAP to use as the uid in Alfresco
-ldap.synchronization.userIdAttributeName=sAMAccountName
+ldap.synchronization.userIdAttributeName=@@LDAP_USER_ATTRIBUTENAME@@
 
 # The attribute on person objects in LDAP to map to the first name property in Alfresco
 ldap.synchronization.userFirstNameAttributeName=givenName

--- a/assets/ldap-authentication.properties
+++ b/assets/ldap-authentication.properties
@@ -90,7 +90,7 @@ ldap.synchronization.modifyTimestampAttributeName=modifyTimestamp
 ldap.synchronization.timestampFormat=yyyyMMddHHmmss'Z'
 
 # The attribute name on people objects found in LDAP to use as the uid in Alfresco
-ldap.synchronization.userIdAttributeName=uid
+ldap.synchronization.userIdAttributeName=@@LDAP_USER_ATTRIBUTENAME@@
 
 # The attribute on person objects in LDAP to map to the first name property in Alfresco
 ldap.synchronization.userFirstNameAttributeName=givenName


### PR DESCRIPTION
Hi,

I'm using your image but I had to modify LDAP configation in `init.sh` to make it work with my OpenLDAP configuration. 
I think it could be useful to other people that don't use `uid` attribute to bind users, so I'm sharing it.

The name of what I use is "search and bind" in Alfresco docs/forums: 
```
# If not set, an LDAP query involving ldap.synchronization.personQuery and ldap.synchronization.userIdAttributeName will
# be performed to resolve the DN dynamically. This allows directories to be structured and doesn't require the user ID to
# appear in the DN.
ldap.authentication.userNameFormat=uid=%s,ou=person,dc=test,dc=alfresco,dc=com
```
To use this method we have let `userNameFormat` to an empty string and set attribute in `userIdAttributeName`.

Example of my `docker-compose.yml`:
```
version: '2'
services:
  app:
    image: jrisp/docker-alfresco:latest
    stdin_open: true
    environment:
      - LDAP_ENABLED=true
      - LDAP_AUTH_USERNAMEFORMAT=
      - LDAP_URL=ldap://ldap.domain.fr:389
      - LDAP_USER_SEARCHBASE=ou=People,dc=domain,dc=fr
      - LDAP_USER_ATTRIBUTENAME=userLogin
```


Hope this PR could be accepted.


BTW, I recommend you to pass parameters within quotes to avoid problems (and to be honest, for me it is cleaner this way). I say that for `cfg_replace_option` calls for example.

I'm open to discussions and changes.

Best Regards,
jri
