### PR TITLE
Script to edit 'share-config-custom.xml' file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY assets/disable_tomcat_CSRF.patch /alfresco/disable_tomcat_CSRF.patch
 # install scripts
 COPY assets/init.sh /alfresco/init.sh
 COPY assets/supervisord.conf /etc/supervisord.conf
+COPY assets/edit_custom_config.py /alfresco/edit_custom_config.py
 
 RUN mkdir -p /alfresco/tomcat/webapps/ROOT
 COPY assets/index.jsp /alfresco/tomcat/webapps/ROOT/

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ using environment variables.
 - **SHARE_PROTOCOL**: protocol use by share to generate links; default = `http`
 - **SYSTEM_SERVERMODE**: the server running mode for you system; default = `PRODUCTION`
 - **TOMCAT_CSRF_ENABLED**: Disable the tomcat CSRF policy; default = `false`
+- **WEBDAV_REPOSITORY_URL**: Webdav base URL in UI; default = `http://localhost:8080/`
 
 ## Upgrading
 TODO: I might be able to add some options that aid in upgrading.  For now

--- a/assets/edit_custom_config.py
+++ b/assets/edit_custom_config.py
@@ -1,0 +1,27 @@
+import os,sys
+from xml.etree import ElementTree as ET
+
+configfile='/alfresco/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml'
+
+doc = ET.parse(configfile)
+
+root = doc.getroot()
+
+def replace_config(root, xpath, value):
+    try:
+        root.findall(xpath)[0].text = value
+        print("Changing "+xpath+" to " + value + ' in ' + configfile)
+    except IOError as e:
+        print "I/O error({0}): {1}".format(e.errno, e.strerror)
+    except ValueError:
+        print "Could not convert data to an integer."
+    except:
+        print "Unexpected error:", sys.exc_info()[0]
+        raise
+
+
+if os.environ.has_key("WEBDAV_REPOSITORY_URL"):
+    replace_config(root,'./config[@condition="DocumentLibrary"]/repository-url', os.environ.get('WEBDAV_REPOSITORY_URL'))
+
+
+doc.write(configfile)

--- a/assets/init.sh
+++ b/assets/init.sh
@@ -213,5 +213,8 @@ if [ "$TOMCAT_CSRF_ENABLED" == "false" ] && [ -f "$TOMCAT_CSRF_PATCH" ] ;then
   [ $? == 0 ] && mv "$TOMCAT_CSRF_PATCH" "${TOMCAT_CSRF_PATCH}.done"
 fi
 
+# Edit share-config-custom.xml
+python /alfresco/edit_custom_config.py 
+
 # start alfresco
 $ALF_HOME/tomcat/scripts/ctl.sh start


### PR DESCRIPTION
Hello,

I've made a python script to edit `share-config-custom.xml`.

My need was to edit webdav path proposed in UI because it was an URL with `http://localhost/...`, but it could be used for many others parameters.

I choose Python to easily manipulate XML file without install any other libs, but feel free to debate.

I'm sharing this, hope this could help. I'm open to suggestions.

Regards,
jri-sp


